### PR TITLE
refactor: schema v2 for more button configurations

### DIFF
--- a/build/mttools/internal_types/generic_values.py
+++ b/build/mttools/internal_types/generic_values.py
@@ -123,21 +123,31 @@ class GenericArrayValue[T](GenericValue[list[T]]):
         """
         Append an item to the internal list. If the internal list is None, error is raised.
         """
-        self.__value.append(item)
+        # Access the internal value directly from parent class
+        value = super().get()  # This gets the actual internal list, not a copy
+        if value is None:
+            raise ValueError("Cannot append to a None value. Set the value first.")
+        value.append(item)
         return self
     
     def extend(self, items: list[T]) -> GenericArrayValue[T]:
         """
         Extend the internal list with items from another list. If the internal list is None, error is raised.
         """
-        self.__value.extend(items)
+        value = super().get()  # This gets the actual internal list, not a copy
+        if value is None:
+            raise ValueError("Cannot extend a None value. Set the value first.")
+        value.extend(items)
         return self
     
     def remove(self, item: T) -> GenericArrayValue[T]:
         """
         Remove an item from the internal list. If the internal list is None, error is raised.
         """
-        self.__value.remove(item)
+        value = super().get()  # This gets the actual internal list, not a copy
+        if value is None:
+            raise ValueError("Cannot remove from a None value. Set the value first.")
+        value.remove(item)
         return self
     
     def clear_array(self) -> GenericArrayValue[T]:
@@ -145,7 +155,10 @@ class GenericArrayValue[T](GenericValue[list[T]]):
         Clear all items from the internal list. If the internal list is None, error is raised.
         If you are looking to set the internal list to None, use `set(None)` or `__call__(None)` instead.
         """
-        self.__value.clear()
+        value = super().get()  # This gets the actual internal list, not a copy
+        if value is None:
+            raise ValueError("Cannot clear a None value. Set the value first.")
+        value.clear()
         return self
     
     def __len__(self) -> int:

--- a/build/mttools/metadata.py
+++ b/build/mttools/metadata.py
@@ -44,10 +44,18 @@ class StaticSiteKeyNode(KeyNode):
         self.document_status: StrValue = StrValue(None)
         self.alias_to: StrValue = StrValue(None)
         self.pdf_viewer: StrValue = StrValue(None)
+        self.buttons: GenericArrayValue[ButtonKeyNode] = GenericArrayValue(None)
 
-        # Sub-keys
-        self.primary_button: PrimaryButtonKeyNode = PrimaryButtonKeyNode(self)
-        self.secondary_button: SecondaryButtonKeyNode = SecondaryButtonKeyNode(self)
+class ButtonKeyNode(KeyNode):
+    def __init__(self, parent_node: StaticSiteKeyNode):
+        super().__init__(parent_node)
+
+        # Keys
+        self.index: IntValue = IntValue(0)
+        self.isPrimary: BoolValue = BoolValue(False)
+        self.text: StrValue = StrValue(None)
+        self.icon: StrValue = StrValue(None)
+        self.href: StrValue = StrValue(None)
 
 class PrimaryButtonKeyNode(KeyNode):
     def __init__(self, parent_node: StaticSiteKeyNode):

--- a/build/mttools/readers/metadata_reader.py
+++ b/build/mttools/readers/metadata_reader.py
@@ -34,6 +34,8 @@ class Reader:
         # select the appropriate parser based on the version
         if version == "1":
             from .metadata_v1_parser import MetadataV1Parser as Parser
+        elif version == "2":
+            from .metadata_v2_parser import MetadataV2Parser as Parser
         else:
             raise ValueError(f"Unsupported metadata file version: {version}")
         

--- a/build/mttools/readers/metadata_reader.py
+++ b/build/mttools/readers/metadata_reader.py
@@ -23,13 +23,30 @@ class Reader:
         # Read the metadata file
         with open(self.metadata_file, 'r') as file:
             metadata_str = file.read()
-        # use regex to find the metadata file version
-        # format: "@metadata_file_version": "<ver>", ...
-        # if not found, raise an error
-        match = re.search(r'"@metadata_file_version"\s*:\s*"([^"]+)"', metadata_str)
-        if not match:
-            raise ValueError("Metadata file version not found.")
-        version = match.group(1)
+        
+        # Determine version: first check $schema, then fall back to @metadata_file_version
+        version = None
+        
+        # Try to detect version from $schema field (v2 format)
+        schema_match = re.search(r'"\$schema"\s*:\s*"([^"]+)"', metadata_str)
+        if schema_match:
+            schema_url = schema_match.group(1)
+            # Check if it's the v2 schema
+            if 'schemas/v2.json' in schema_url:
+                version = "2"
+        
+        # Fall back to @metadata_file_version field (v1 and legacy v2 format)
+        if version is None:
+            version_match = re.search(r'"@metadata_file_version"\s*:\s*"([^"]+)"', metadata_str)
+            if version_match:
+                version = version_match.group(1)
+        
+        # If no version indicator found, raise an error
+        if version is None:
+            raise ValueError(
+                "Metadata file version could not be determined. "
+                "Please include either '$schema' field (v2) or '@metadata_file_version' field (v1)."
+            )
 
         # select the appropriate parser based on the version
         if version == "1":

--- a/build/mttools/readers/metadata_v1_parser.py
+++ b/build/mttools/readers/metadata_v1_parser.py
@@ -117,18 +117,30 @@ class MetadataV1Parser(MetadataParserBase):
         # V2 format no longer uses static_site.primary_button and static_site.secondary_button keys.
         # Instead, an object array static_site.buttons is used to define buttons.
         # Old format primary_button and secondary_button will be converted to buttons array here.
+        # NOTE: In V1, if no button configuration is provided, default buttons are created.
+        # This maintains backward compatibility with the old format.
 
         self.parsed_obj.static_site.buttons.set([])
 
         # "static_site" > "primary_button" keys
-        primary_disabled_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("disabled")
-        if isinstance(primary_disabled_val, bool) and not primary_disabled_val:
+        primary_button_obj = self.json_obj.get("static_site", {}).get("primary_button")
+        # In V1 format, if primary_button key doesn't exist, we treat it as enabled with defaults
+        # If it exists, we check the disabled field
+        if primary_button_obj is None:
+            # No configuration = create default button
+            primary_disabled_val = False
+            primary_button_obj = {}
+        else:
+            primary_disabled_val = primary_button_obj.get("disabled")
+        
+        # Create button if disabled is not True (i.e., if disabled is False or not present)
+        if primary_disabled_val is not True:
             primary_button = ButtonKeyNode(self.parsed_obj.static_site)
             primary_button.isPrimary.set(True)
             primary_button.index.set(0)
-            primary_text_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("text")
-            primary_icon_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("icon")
-            primary_href_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("href")
+            primary_text_val = primary_button_obj.get("text")
+            primary_icon_val = primary_button_obj.get("icon")
+            primary_href_val = primary_button_obj.get("href")
             primary_button.text.set_if_else(
                 primary_text_val,
                 lambda: primary_text_val is not None,
@@ -148,14 +160,24 @@ class MetadataV1Parser(MetadataParserBase):
             self.parsed_obj.static_site.buttons.append(primary_button)
 
         # "static_site" > "secondary_button" keys
-        secondary_disabled_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("disabled")
-        if isinstance(secondary_disabled_val, bool) and not secondary_disabled_val:
+        secondary_button_obj = self.json_obj.get("static_site", {}).get("secondary_button")
+        # In V1 format, if secondary_button key doesn't exist, we treat it as enabled with defaults
+        # If it exists, we check the disabled field
+        if secondary_button_obj is None:
+            # No configuration = create default button
+            secondary_disabled_val = False
+            secondary_button_obj = {}
+        else:
+            secondary_disabled_val = secondary_button_obj.get("disabled")
+        
+        # Create button if disabled is not True (i.e., if disabled is False or not present)
+        if secondary_disabled_val is not True:
             secondary_button = ButtonKeyNode(self.parsed_obj.static_site)
             secondary_button.isPrimary.set(False)
             secondary_button.index.set(1)
-            secondary_text_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("text")
-            secondary_icon_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("icon")
-            secondary_href_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("href")
+            secondary_text_val = secondary_button_obj.get("text")
+            secondary_icon_val = secondary_button_obj.get("icon")
+            secondary_href_val = secondary_button_obj.get("href")
             secondary_button.text.set_if_else(
                 secondary_text_val,
                 lambda: secondary_text_val is not None,

--- a/build/mttools/readers/metadata_v1_parser.py
+++ b/build/mttools/readers/metadata_v1_parser.py
@@ -1,5 +1,5 @@
 from .metadata_base_parser import MetadataParserBase
-from ..metadata import Metadata
+from ..metadata import Metadata, ButtonKeyNode
 
 class MetadataV1Parser(MetadataParserBase):
     """
@@ -113,71 +113,66 @@ class MetadataV1Parser(MetadataParserBase):
             "at_head"
         )
 
+        ### COMPATIBILITY WITH V2 FORMAT ###
+        # V2 format no longer uses static_site.primary_button and static_site.secondary_button keys.
+        # Instead, an object array static_site.buttons is used to define buttons.
+        # Old format primary_button and secondary_button will be converted to buttons array here.
+
+        self.parsed_obj.static_site.buttons.set([])
+
         # "static_site" > "primary_button" keys
-        # primary_button.disabled - default: false
         primary_disabled_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("disabled")
-        self.parsed_obj.static_site.primary_button.disabled.set_if_else(
-            primary_disabled_val,
-            lambda: primary_disabled_val is not None,
-            False
-        )
-        
-        # primary_button.text - default: "Download"
-        primary_text_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("text")
-        self.parsed_obj.static_site.primary_button.text.set_if_else(
-            primary_text_val,
-            lambda: primary_text_val is not None,
-            "Download"
-        )
-        
-        # primary_button.icon - default: "material-download"
-        primary_icon_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("icon")
-        self.parsed_obj.static_site.primary_button.icon.set_if_else(
-            primary_icon_val,
-            lambda: primary_icon_val is not None,
-            "material-download"
-        )
-        
-        # primary_button.href - default: computed
-        primary_href_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("href")
-        self.parsed_obj.static_site.primary_button.href.set_if_else(
-            primary_href_val,
-            lambda: primary_href_val is not None,
-            f"https://hku.jacobshing.com/files/{self.parsed_obj.name.get()}/{self.parsed_obj.output_file.get()}"
-        )
+        if isinstance(primary_disabled_val, bool) and not primary_disabled_val:
+            primary_button = ButtonKeyNode(self.parsed_obj.static_site)
+            primary_button.isPrimary.set(True)
+            primary_button.index.set(0)
+            primary_text_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("text")
+            primary_icon_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("icon")
+            primary_href_val = self.json_obj.get("static_site", {}).get("primary_button", {}).get("href")
+            primary_button.text.set_if_else(
+                primary_text_val,
+                lambda: primary_text_val is not None,
+                "Download"
+            )
+            primary_button.icon.set_if_else(
+                primary_icon_val,
+                lambda: primary_icon_val is not None,
+                "material-download"
+            )
+            primary_button.href.set_if_else(
+                primary_href_val,
+                lambda: primary_href_val is not None,
+                f"https://hku.jacobshing.com/files/{self.parsed_obj.name.get()}/{self.parsed_obj.output_file.get()}"
+            )
+            
+            self.parsed_obj.static_site.buttons.append(primary_button)
 
         # "static_site" > "secondary_button" keys
-        # secondary_button.disabled - default: false
         secondary_disabled_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("disabled")
-        self.parsed_obj.static_site.secondary_button.disabled.set_if_else(
-            secondary_disabled_val,
-            lambda: secondary_disabled_val is not None,
-            False
-        )
-        
-        # secondary_button.text - default: "View source"
-        secondary_text_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("text")
-        self.parsed_obj.static_site.secondary_button.text.set_if_else(
-            secondary_text_val,
-            lambda: secondary_text_val is not None,
-            "View source"
-        )
-        
-        # secondary_button.icon - default: "material-github"
-        secondary_icon_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("icon")
-        self.parsed_obj.static_site.secondary_button.icon.set_if_else(
-            secondary_icon_val,
-            lambda: secondary_icon_val is not None,
-            "material-github"
-        )
-        
-        # secondary_button.href - default: computed
-        secondary_href_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("href")
-        self.parsed_obj.static_site.secondary_button.href.set_if_else(
-            secondary_href_val,
-            lambda: secondary_href_val is not None,
-            f"https://github.com/ShingZhanho/HKU-Notes/tree/master/src/{self.parsed_obj.name.get()}"
-        )
+        if isinstance(secondary_disabled_val, bool) and not secondary_disabled_val:
+            secondary_button = ButtonKeyNode(self.parsed_obj.static_site)
+            secondary_button.isPrimary.set(False)
+            secondary_button.index.set(1)
+            secondary_text_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("text")
+            secondary_icon_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("icon")
+            secondary_href_val = self.json_obj.get("static_site", {}).get("secondary_button", {}).get("href")
+            secondary_button.text.set_if_else(
+                secondary_text_val,
+                lambda: secondary_text_val is not None,
+                "View source"
+            )
+            secondary_button.icon.set_if_else(
+                secondary_icon_val,
+                lambda: secondary_icon_val is not None,
+                "material-github"
+            )
+            secondary_button.href.set_if_else(
+                secondary_href_val,
+                lambda: secondary_href_val is not None,
+                f"https://github.com/ShingZhanho/HKU-Notes/tree/master/src/{self.parsed_obj.name.get()}"
+            )
+            
+            self.parsed_obj.static_site.buttons.append(secondary_button)
 
         # "authors" keys - default: ["jacob_shing"]
         authors_val = self.json_obj.get("authors")

--- a/build/mttools/readers/metadata_v2_parser.py
+++ b/build/mttools/readers/metadata_v2_parser.py
@@ -1,0 +1,172 @@
+from .metadata_base_parser import MetadataParserBase
+from ..metadata import Metadata, ButtonKeyNode
+
+class MetadataV2Parser(MetadataParserBase):
+    """
+    Parser for version 2 of the metadata file.
+    """
+    def __init__(self, metadata_file, build_target):
+        """
+        Initialize the parser with a metadata file.
+        """
+        super().__init__(metadata_file, build_target)
+
+    def parse(self) -> Metadata:
+        # Top-level keys
+        root_file_val = self.json_obj.get("build", {}).get("root_file")
+        self.parsed_obj.root_file.set_if(
+            root_file_val,
+            lambda: root_file_val is not None
+        )
+        
+        output_file_val = self.json_obj.get("build", {}).get("output_file")
+        self.parsed_obj.output_file.set_if(
+            output_file_val,
+            lambda: output_file_val is not None
+        )
+
+        # "build" sub-keys
+        requires_val = self.json_obj.get("build", {}).get("requires")
+        self.parsed_obj.build.requires.set_if(
+            requires_val,
+            lambda: requires_val is not None
+        )
+        
+        # build.no_latex - default: false
+        no_latex_val = self.json_obj.get("build", {}).get("no_latex")
+        self.parsed_obj.build.no_latex.set_if_else(
+            no_latex_val,
+            lambda: no_latex_val is not None,
+            False
+        )
+        
+        prebuild_command_val = self.json_obj.get("build", {}).get("prebuild_command")
+        self.parsed_obj.build.prebuild_command.set_if(
+            prebuild_command_val,
+            lambda: prebuild_command_val is not None
+        )
+        
+        # build.build_command - default: computed based on root_file
+        build_command_val = self.json_obj.get("build", {}).get("build_command")
+        self.parsed_obj.build.build_command.set_if_else(
+            build_command_val,
+            lambda: build_command_val is not None,
+            f"latexmk -pdf -f -interaction=nonstopmode -cd -outdir=. ./{self.parsed_obj.root_file.get()}"
+        )
+        
+        postbuild_command_val = self.json_obj.get("build", {}).get("postbuild_command")
+        self.parsed_obj.build.postbuild_command.set_if(
+            postbuild_command_val,
+            lambda: postbuild_command_val is not None
+        )
+        
+        # build.miktex_package_file - default: "packages.tex"
+        miktex_package_file_val = self.json_obj.get("build", {}).get("miktex_package_file")
+        self.parsed_obj.build.miktex_package_file.set_if_else(
+            miktex_package_file_val,
+            lambda: miktex_package_file_val is not None,
+            "packages.tex"
+        )
+
+        # "static_site" keys
+        # static_site.description - default: "-"
+        description_val = self.json_obj.get("static_site", {}).get("description")
+        self.parsed_obj.static_site.description.set_if_else(
+            description_val,
+            lambda: description_val is not None,
+            "-"
+        )
+        
+        meta_description_val = self.json_obj.get("static_site", {}).get("meta_description")
+        self.parsed_obj.static_site.meta_description.set_if(
+            meta_description_val,
+            lambda: meta_description_val is not None
+        )
+        
+        # static_site.custom_md_file - default: ""
+        custom_md_file_val = self.json_obj.get("static_site", {}).get("custom_md_file")
+        self.parsed_obj.static_site.custom_md_file.set_if_else(
+            custom_md_file_val,
+            lambda: custom_md_file_val is not None,
+            ""
+        )
+        
+        # static_site.document_status - default: "unk"
+        document_status_val = self.json_obj.get("static_site", {}).get("document_status")
+        self.parsed_obj.static_site.document_status.set_if_else(
+            document_status_val,
+            lambda: document_status_val is not None,
+            "unk"
+        )
+        
+        alias_to_val = self.json_obj.get("static_site", {}).get("alias_to")
+        self.parsed_obj.static_site.alias_to.set_if(
+            alias_to_val,
+            lambda: alias_to_val is not None
+        )
+        
+        # static_site.pdf_viewer - default: "at_head"
+        pdf_viewer_val = self.json_obj.get("static_site", {}).get("pdf_viewer")
+        self.parsed_obj.static_site.pdf_viewer.set_if_else(
+            pdf_viewer_val,
+            lambda: pdf_viewer_val is not None,
+            "at_head"
+        )
+
+        # "static_site" > "buttons"
+        buttons_val = self.json_obj.get("static_site", {}).get("buttons")
+        # if buttons_val is None, create two default buttons
+        buttons_dicts: list[dict] = []
+        if buttons_val is None:
+            buttons_dicts = [
+                {
+                    "isPrimary": True,
+                    "text": "Download",
+                    "icon": "material-download",
+                    "href": f"https://hku.jacobshing.com/files/{self.parsed_obj.name.get()}/{self.parsed_obj.output_file.get()}"
+                },
+                {
+                    "isPrimary": False,
+                    "text": "View source",
+                    "icon": "material-github",
+                    "href": f"https://github.com/ShingZhanho/HKU-Notes/tree/master/src/{self.parsed_obj.name.get()}"
+                }
+            ]
+        elif isinstance(buttons_val, list):
+            buttons_dicts = buttons_val
+
+        def create_button_node(button_dict: dict) -> ButtonKeyNode:
+            button_node = ButtonKeyNode(self.parsed_obj.static_site)
+            button_node.index.set_if_else(
+                button_dict.get("index"),
+                lambda: button_dict.get("index") is not None,
+                0
+            )
+            button_node.isPrimary.set_if_else(
+                button_dict.get("isPrimary"),
+                lambda: button_dict.get("isPrimary") is not None,
+                False
+            )
+            if not button_dict.get("text"):
+                raise ValueError("You must provide 'text' for each button.")
+            button_node.text.set(button_dict.get("text"))
+            button_node.icon.set(button_dict.get("icon")) # icon can be None
+            if not button_dict.get("href"):
+                raise ValueError("You must provide 'href' for each button.")
+            button_node.href.set(button_dict.get("href"))
+            return button_node
+        
+        button_nodes = [create_button_node(b_dict) for b_dict in buttons_dicts]
+        # sort button nodes by index
+        button_nodes.sort(key=lambda b: b.index.get())
+        self.parsed_obj.static_site.buttons.set(button_nodes)
+
+        # "authors" keys - default: ["jacob_shing"]
+        authors_val = self.json_obj.get("authors")
+        self.parsed_obj.authors.set_if_else(
+            authors_val,
+            lambda: authors_val is not None,
+            ["jacob_shing"]
+        )
+
+        return self.parsed_obj

--- a/build/mttools/readers/metadata_v2_parser.py
+++ b/build/mttools/readers/metadata_v2_parser.py
@@ -1,5 +1,6 @@
 from .metadata_base_parser import MetadataParserBase
 from ..metadata import Metadata, ButtonKeyNode
+import jsonschema
 
 class MetadataV2Parser(MetadataParserBase):
     """
@@ -10,6 +11,17 @@ class MetadataV2Parser(MetadataParserBase):
         Initialize the parser with a metadata file.
         """
         super().__init__(metadata_file, build_target)
+        # Validate JSON against v2 schema
+        self.__validate_json(self.metadata_file)
+
+    @staticmethod
+    def __validate_json(json_str: str) -> None:
+        """
+        Validate the JSON string against the v2 schema.
+        """
+        SCHEMA_URL = "https://hku.jacobshing.com/statics/schemas/v2.json"
+        schema = jsonschema.validators.validator_for({"$schema": SCHEMA_URL}).META_SCHEMA
+        jsonschema.validate(instance=json_str, schema=schema)
 
     def parse(self) -> Metadata:
         # Top-level keys

--- a/build/page_gen_tools/gen_details_page.py
+++ b/build/page_gen_tools/gen_details_page.py
@@ -44,20 +44,13 @@ def gen_details_page(target: str, metadata: Metadata, all_targets: dict[str, dic
     print("Authors section written.")
 
     # Writ buttons
-    if not metadata.static_site.primary_button.disabled.get():
-        f.write(f"\n{__generate_button_md(
-            True,
-            metadata.static_site.primary_button.text.get(),
-            metadata.static_site.primary_button.href.get(),
-            metadata.static_site.primary_button.icon.get()
-        )}")
-    if not metadata.static_site.secondary_button.disabled.get():
-        f.write(f"\n{__generate_button_md(
-            False,
-            metadata.static_site.secondary_button.text.get(),
-            metadata.static_site.secondary_button.href.get(),
-            metadata.static_site.secondary_button.icon.get()
-        )}")
+    for button in metadata.static_site.buttons.get():
+        f.write(__generate_button_md(
+            button.isPrimary.get(),
+            button.text.get(),
+            button.href.get(),
+            button.icon.get()
+        ))
     f.write("\n\n")
     print("Buttons written.")
 

--- a/build/python-requirement-lists/mkdocs-material-pkgs.txt
+++ b/build/python-requirement-lists/mkdocs-material-pkgs.txt
@@ -3,3 +3,4 @@ selectolax==0.3.29
 mkdocs-glightbox==0.5.2
 google-api-python-client==2.185.0
 oauth2client==4.1.3
+jsonschema==4.25.1

--- a/site/docs/contribution/syntax-reference/metadata.json.md
+++ b/site/docs/contribution/syntax-reference/metadata.json.md
@@ -8,10 +8,6 @@ The `metadata.json` file is used to define the metadata for each build target in
 This file is required for each build target as it contains information about how the target should be built,
 how it should be displayed and presented on the website.
 
-## Schema (v1)
-
-The current latest schema version is `1`. It has only one required field, which is the version number. All other fields are optional.
-
 !!! note "Key Naming Conventions"
 
     All keys in the `metadata.json` file should be in `snake_case` format.
@@ -38,10 +34,94 @@ The current latest schema version is `1`. It has only one required field, which 
         }
         ```
 
+## Schema (v2)
+
+The current latest schema version is `2`. It has only one required field, which is the version number. All other fields are optional.
+All keys and their behaviours remain unchanged as in version `1`, except for those listed below.
+
+### Changes from `v1` to `v2`
+
+- `static_site.primary_button` and `static_site.secondary_button` have been replaced with `static_site.buttons`, an array of button objects.
+
+!!! note "Recommendation and Compatibility"
+
+    For new build targets, it is recommended to use the `v2` schema.
+
+    The build pipeline will automatically parse v1 formats and convert them to v2 internally,
+    so existing build targets using v1 schema will continue to work without any changes.
+
 ### `@metadata_file_version`
 
 - **Required**: Yes
-- **Description**: The version of the metadata file schema. Must be set to `"1"`.
+- **Description**: The version of the metadata file schema. Must be set to `"2"` to use the v2 schema.
+- **Type**: `string`
+
+### `static_site.buttons`
+
+- **Description**: An array of button objects that define the buttons to be displayed on the static site.
+Each button object must conform the structure described below.
+- **Type**: `array` of `object`
+- **Default**: `null`
+
+!!! note "Default Value Behaviour"
+
+    If the `static_site.buttons` key has the default value of `null`, the build pipeline will
+    automatically create two buttons: a primary "Download" button and a secondary "View Source" button,
+    with the same properties as in the v1 schema.
+
+    However, if you wish to display no buttons, you must explicitly set `static_site.buttons` to an empty array `[]`.
+
+#### `static_site.buttons[i].{index}`
+
+- **Description**: The index of the button in the array. Used to determine the order of buttons.
+- **Type**: `integer`
+- **Default**: `0`
+
+!!! warning "Default Index Undefined Behaviour"
+
+    By default, all buttons have an index of `0`, which means their order can be inconsistent between builds.
+    You should explicitly set **distinct** indices for each button to ensure a consistent order.
+
+#### `static_site.buttons[i].{isPrimary}`
+
+- **Description**: Whether the button is a primary button or not.
+- **Type**: `boolean`
+- **Default**: `false`
+
+!!! note "Multiple Primary Buttons and Ordering"
+
+    It is allowed to have multiple primary buttons.
+    
+    The order of buttons is soley determined by their `index` values, regardless of whether they are primary or secondary.
+    Buttons with lower index values are displayed before buttons with higher index values.
+
+#### `static_site.buttons[i].{text}`
+
+- **Required**: Yes
+- **Description**: The text to be displayed on the button. You must explicitly set this value for each button.
+- **Type**: `string`
+
+#### `static_site.buttons[i].{icon}`
+
+- **Description**: Defines the icon and href of the button.
+- **Type**: `string`
+- **Default**: `null` (no icon)
+- **Accepted Values**: Any valid icon name specified in the [Material for MkDocs documentation](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/),
+
+#### `static_site.buttons[i].{href}`
+
+- **Required**: Yes
+- **Description**: The URL to be linked to when the button is clicked. You must explicitly set this value for each button.
+- **Type**: `string`
+
+## Schema (v1)
+
+The following sections describe the keys available in the `metadata.json` file for schema version `1`.
+
+### `@metadata_file_version`
+
+- **Required**: Yes
+- **Description**: The version of the metadata file schema. Set to `"1"` for this version.
 - **Type**: `string`
 
 ### `build.root_file`
@@ -222,7 +302,7 @@ A disabled button will not be displayed on the static site.
 - **Description**: The icon to be displayed on the primary/secondary button.
 - **Type**: `string`
 - **Default**: `"material-download"` for primary button, and `"material-github"` for secondary button.
-- **Accepted Values**: Any valid icon name specified in the [Material for MkDocs documentation](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis.html),
+- **Accepted Values**: Any valid icon name specified in the [Material for MkDocs documentation](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/),
 or empty string for no icon.
 
 ### `static_site.{primary_button, secondary_button}.href`

--- a/site/docs/contribution/syntax-reference/metadata.json.md
+++ b/site/docs/contribution/syntax-reference/metadata.json.md
@@ -8,6 +8,16 @@ The `metadata.json` file is used to define the metadata for each build target in
 This file is required for each build target as it contains information about how the target should be built,
 how it should be displayed and presented on the website.
 
+!!! info "Version Detection"
+
+    The build pipeline automatically detects the schema version of each `metadata.json` file using the following priority:
+
+    1. **`$schema` field** - If present and contains `schemas/v2.json`, the file is treated as v2
+    2. **`@metadata_file_version` field** - Legacy method for both v1 and v2
+    3. **Error** - If neither field is present, the build will fail
+
+    For new files, use the `$schema` field (v2 format). Existing files with `@metadata_file_version` will continue to work.
+
 !!! note "Key Naming Conventions"
 
     All keys in the `metadata.json` file should be in `snake_case` format.
@@ -34,27 +44,65 @@ how it should be displayed and presented on the website.
         }
         ```
 
+    An arbitrary object of an array is denoted using `[i]`. The keys of the object are enclosed
+    within curly braces `{}`.
+
+    ??? example
+
+        The key `static_site.buttons[i].{text}` would mean:
+
+        ```json
+        {
+            "static_site": {
+                "buttons": [
+                    {
+                        "text": "Button 1"
+                    },
+                    {
+                        "text": "Button 2"
+                    }
+                ]
+            }
+        }
+        ```
+
 ## Schema (v2)
 
-The current latest schema version is `2`. It has only one required field, which is the version number. All other fields are optional.
+The current latest schema version is `2`. It has only one required field: `$schema`. All other fields are optional.
 All keys and their behaviours remain unchanged as in version `1`, except for those listed below.
 
 ### Changes from `v1` to `v2`
 
 - `static_site.primary_button` and `static_site.secondary_button` have been replaced with `static_site.buttons`, an array of button objects.
+- Version is now specified using the `$schema` field instead of `@metadata_file_version`.
 
 !!! note "Recommendation and Compatibility"
 
-    For new build targets, it is recommended to use the `v2` schema.
+    For new build targets, it is recommended to use the `v2` schema with the `$schema` field.
 
     The build pipeline will automatically parse v1 formats and convert them to v2 internally,
     so existing build targets using v1 schema will continue to work without any changes.
 
-### `@metadata_file_version`
+### `$schema`
 
 - **Required**: Yes
-- **Description**: The version of the metadata file schema. Must be set to `"2"` to use the v2 schema.
+- **Description**: Reference to the JSON schema for validation and IDE support. Must be set to the v2 schema URL.
 - **Type**: `string`
+- **Value**: `"https://hku.jacobshing.com/statics/schemas/v2.json"`
+
+### ~~`@metadata_file_version`~~ **[Deprecated]**
+
+!!! warning "Deprecated Field"
+
+    The `@metadata_file_version` field is deprecated in v2 and replaced by the `$schema` field.
+    
+    For backward compatibility, you may still include this field (set to `"2"`), but it is no longer
+    required or recommended for new files. The build pipeline will prioritize `$schema` for version detection.
+
+- **Required**: No (deprecated)
+- **Description**: Legacy field for specifying metadata schema version. Replaced by `$schema` in v2.
+- **Type**: `string`
+- **Value**: `"2"` (if present)
 
 ### `static_site.buttons`
 

--- a/site/docs/statics/schemas/v2.json
+++ b/site/docs/statics/schemas/v2.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://hku.jacobshing.com/statics/schemas/v2.json",
+  "title": "HKU Notes Metadata Schema v2",
+  "description": "Schema for metadata.json files in the HKU Notes project (version 2)",
+  "type": "object",
+  "required": ["$schema"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this JSON schema for validation and IDE support. Must point to this schema.",
+      "const": "https://hku.jacobshing.com/statics/schemas/v2.json"
+    },
+    "@metadata_file_version": {
+      "type": "string",
+      "const": "2",
+      "description": "Optional field for backward compatibility. The version is now determined by the $schema field.",
+      "deprecated": true
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "root_file": {
+          "type": "string",
+          "description": "Specifies the main file to be built for the target.",
+          "pattern": "^.+\\.(tex|md|html)$"
+        },
+        "output_file": {
+          "type": "string",
+          "description": "Specifies the name of the output file to be generated after building the target."
+        },
+        "no_latex": {
+          "type": "boolean",
+          "description": "If true, the build pipeline will skip the LaTeX installation.",
+          "default": false
+        },
+        "requires": {
+          "type": "array",
+          "description": "A list of dependencies that are required to build the target.",
+          "items": {
+            "type": "string",
+            "enum": ["python-minted-pkgs"]
+          },
+          "uniqueItems": true
+        },
+        "prebuild_command": {
+          "type": "string",
+          "description": "A command to run before building the target."
+        },
+        "build_command": {
+          "type": "string",
+          "description": "The command to build the target."
+        },
+        "postbuild_command": {
+          "type": "string",
+          "description": "A command to run after building the target."
+        },
+        "miktex_package_file": {
+          "type": "string",
+          "description": "Deprecated. Specifies the .tex file that contains all the \\usepackage commands.",
+          "deprecated": true
+        }
+      }
+    },
+    "static_site": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A short description of the target, used in the static site.",
+          "default": "-"
+        },
+        "meta_description": {
+          "type": "string",
+          "description": "A short description of the target, used in the HTML meta tags for SEO purposes."
+        },
+        "custom_md_file": {
+          "type": "string",
+          "description": "A custom Markdown file whose content will be copied to the end of the static site page.",
+          "default": ""
+        },
+        "document_status": {
+          "type": "string",
+          "description": "The status of the document, used in the static site.",
+          "pattern": "^[a-z]{3}$",
+          "default": "unk"
+        },
+        "alias_to": {
+          "type": "string",
+          "description": "Treats the target as an alias to another build target."
+        },
+        "pdf_viewer": {
+          "type": "string",
+          "description": "Where the PDF viewer should be displayed on the details page.",
+          "enum": ["at_head", "at_footer", "at_tag", "hidden"],
+          "default": "at_head"
+        },
+        "buttons": {
+          "description": "An array of button objects that define the buttons to be displayed on the static site.",
+          "oneOf": [
+            {
+              "type": "null",
+              "description": "If null, two default buttons (Download and View Source) will be created automatically."
+            },
+            {
+              "type": "array",
+              "description": "Array of button objects. Use an empty array [] to display no buttons.",
+              "items": {
+                "type": "object",
+                "required": ["text", "href"],
+                "additionalProperties": false,
+                "properties": {
+                  "index": {
+                    "type": "integer",
+                    "description": "The index of the button in the array. Used to determine the order of buttons.",
+                    "default": 0
+                  },
+                  "isPrimary": {
+                    "type": "boolean",
+                    "description": "Whether the button is a primary button or not.",
+                    "default": false
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "The text to be displayed on the button.",
+                    "minLength": 1
+                  },
+                  "icon": {
+                    "type": ["string", "null"],
+                    "description": "The icon to be displayed on the button. Use null or omit for no icon.",
+                    "default": null
+                  },
+                  "href": {
+                    "type": "string",
+                    "description": "The URL to be linked to when the button is clicked.",
+                    "minLength": 1,
+                    "format": "uri-reference"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "authors": {
+      "type": "array",
+      "description": "A list of authors for the target.",
+      "items": {
+        "type": "string",
+        "pattern": "^(!)?(@unknown|@do_not_sort|[a-z_][a-z0-9_]*)$"
+      },
+      "default": ["jacob_shing"],
+      "minItems": 1
+    }
+  }
+}


### PR DESCRIPTION
Updates metadata parsing to support a new button configuration schema.

This change introduces a new version (v2) of the metadata schema that replaces the `primary_button` and `secondary_button` keys with a more flexible `buttons` array. This allows for more than two buttons, and custom ordering through the `index` field. The old v1 format is still supported through a compatibility layer.

Key changes:

- Adds a `ButtonKeyNode` class to represent individual button configurations.
- Introduces `metadata_v2_parser.py` to handle the new metadata schema.
- Modifies `metadata_v1_parser.py` to convert v1 button configurations to the v2 format, ensuring backward compatibility.
- Updates `metadata.json.md` to document the new v2 schema.
- Modifies `gen_details_page.py` to iterate through the buttons array when generating the details page.